### PR TITLE
fix: git_branch を有効化してプロンプトのブランチ表示を復活

### DIFF
--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -19,12 +19,8 @@ symbol = "🧊 "
 [gcloud]
 disabled = true
 
-[git_branch]
-disabled = true
-
 [docker_context]
 disabled = true
 
 [terraform]
 disabled = true
-

--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -18,6 +18,9 @@ symbol = "[⬢](bold green) "
 [pulumi]
 symbol = "🧊 "
 
+[git_branch]
+format = "[$symbol$branch]($style) "
+
 [gcloud]
 disabled = true
 

--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -1,5 +1,7 @@
 command_timeout = 3000
 
+right_format = "$git_branch"
+
 [battery]
 full_symbol = "• "
 charging_symbol = "⇡ "


### PR DESCRIPTION
## Summary

Closes #35

- `.config/starship.toml` の `[git_branch] disabled = true` を削除
- `right_format = "$git_branch"` を追加して、**画面右端**にブランチ名を表示するよう修正

### 変更内容

```diff
 command_timeout = 3000

+right_format = "$git_branch"
+
 [battery]
 ...
-
-[git_branch]
-disabled = true
```

## 原因

PR #34 以前から `.config/starship.toml` に `[git_branch] disabled = true` が設定されており、さらに右端表示に必要な `right_format` の設定が欠けていた。

## Test plan

- [ ] `source ~/.zshrc` を実行後、git リポジトリ内で画面**右端**にブランチ名が表示されることを確認